### PR TITLE
RepeatableReadResultSetProxyLogic triggers invalid cast between numeric types

### DIFF
--- a/src/main/java/net/ttddyy/dsproxy/proxy/RepeatableReadResultSetProxyLogic.java
+++ b/src/main/java/net/ttddyy/dsproxy/proxy/RepeatableReadResultSetProxyLogic.java
@@ -1,5 +1,6 @@
 package net.ttddyy.dsproxy.proxy;
 
+import java.util.HashMap;
 import net.ttddyy.dsproxy.ConnectionInfo;
 import net.ttddyy.dsproxy.listener.MethodExecutionListenerUtils;
 
@@ -239,7 +240,7 @@ public class RepeatableReadResultSetProxyLogic implements ResultSetProxyLogic {
         }
     }
 
-    private Object handleGetMethodUsingCache(Method method, Object[] args) throws SQLException {
+    private Object handleGetMethodUsingCache(Method method, Object[] args) throws SQLException, InvocationTargetException, IllegalAccessException {
         if (resultPointer == -1) {
             throw new SQLException("Result set not advanced. Call next before any get method!");
         } else if (resultPointer < cachedResults.size()) {

--- a/src/main/java/net/ttddyy/dsproxy/proxy/RepeatableReadResultSetProxyLogic.java
+++ b/src/main/java/net/ttddyy/dsproxy/proxy/RepeatableReadResultSetProxyLogic.java
@@ -5,7 +5,6 @@ import net.ttddyy.dsproxy.listener.MethodExecutionListenerUtils;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Type;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.*;
@@ -17,6 +16,7 @@ import static java.lang.String.format;
  * Allows {@link java.sql.ResultSet} to be consumed more than once.
  *
  * @author Liam Williams
+ * @author Réda Housni Alaoui
  * @see net.ttddyy.dsproxy.proxy.jdk.ResultSetInvocationHandler
  * @since 1.4
  */
@@ -34,6 +34,19 @@ public class RepeatableReadResultSetProxyLogic implements ResultSetProxyLogic {
                 }
             }
     );
+
+    private static final Map<String, Method> NUMBER_X_VALUE_METHOD_PER_NUMERIC_TYPE = Collections.unmodifiableMap(new HashMap<String, Method>() {
+        private static final String METHOD_SUFFIX = "Value";
+        {
+            for (Method method : Number.class.getDeclaredMethods()) {
+                String methodName = method.getName();
+                if (!methodName.endsWith(METHOD_SUFFIX)) {
+                    continue;
+                }
+                put(methodName.substring(0, methodName.indexOf(METHOD_SUFFIX)), method);
+            }
+        }
+    });
 
     private static final Object UNCONSUMED_RESULT_COLUMN = new Object();
 
@@ -144,7 +157,7 @@ public class RepeatableReadResultSetProxyLogic implements ResultSetProxyLogic {
         }
         if (this.resultSetConsumed) {
             if (isGetMethod(method)) {
-                return handleGetMethodUsingCache(args);
+                return handleGetMethodUsingCache(methodName, args);
             }
             if (isNextMethod(method)) {
                 return handleNextMethodUsingCache();
@@ -213,15 +226,28 @@ public class RepeatableReadResultSetProxyLogic implements ResultSetProxyLogic {
         }
     }
 
-    private Object handleGetMethodUsingCache(Object[] args) throws SQLException {
+    private Object handleGetMethodUsingCache(String methodName, Object[] args) throws SQLException, InvocationTargetException, IllegalAccessException {
         if (resultPointer == -1) {
             throw new SQLException("Result set not advanced. Call next before any get method!");
         } else if (resultPointer < cachedResults.size()) {
             int columnIndex = determineColumnIndex(args);
-            return currentResult[columnIndex];
+            Object columnValue = currentResult[columnIndex];
+            if (!(columnValue instanceof Number)) {
+                return columnValue;
+            }
+            return convertNumberToExpectedType(methodName, (Number) columnValue);
         } else {
             throw new SQLException(format("Result set exhausted. There were %d result(s) only", cachedResults.size()));
         }
+    }
+
+    private Object convertNumberToExpectedType(String getMethodName, Number value) throws InvocationTargetException, IllegalAccessException {
+        String targetTypeName = getMethodName.substring("get".length()).toLowerCase();
+        Method converter = NUMBER_X_VALUE_METHOD_PER_NUMERIC_TYPE.get(targetTypeName);
+        if (converter == null) {
+            return value;
+        }
+        return converter.invoke(value);
     }
 
     private boolean isGetMethod(Method method) {

--- a/src/test/java/net/ttddyy/dsproxy/proxy/RepeatableReadResultSetProxyLogicTest.java
+++ b/src/test/java/net/ttddyy/dsproxy/proxy/RepeatableReadResultSetProxyLogicTest.java
@@ -304,6 +304,11 @@ public class RepeatableReadResultSetProxyLogicTest {
         return (Integer) resultSetProxyLogic.invoke(getInt, new Object[]{columnIndex});
     }
 
+    private long invokeGetLong(RepeatableReadResultSetProxyLogic resultSetProxyLogic, int columnIndex) throws Throwable {
+        Method getInt = ResultSet.class.getMethod("getLong", int.class);
+        return (Long) resultSetProxyLogic.invoke(getInt, new Object[]{columnIndex});
+    }
+
     private Timestamp invokeGetTimestamp(RepeatableReadResultSetProxyLogic resultSetProxyLogic, int columnIndex) throws Throwable {
         Method getTimestamp = ResultSet.class.getMethod("getTimestamp", int.class);
         return (Timestamp) resultSetProxyLogic.invoke(getTimestamp, new Object[]{columnIndex});
@@ -405,6 +410,25 @@ public class RepeatableReadResultSetProxyLogicTest {
         assertSame("close", executionContext.getMethod().getName());
         assertSame(rs, executionContext.getTarget());
         assertSame(connectionInfo, executionContext.getConnectionInfo());
+    }
+
+    @Test
+    public void getIntThenGetLong() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        RepeatableReadResultSetProxyLogic resultSetProxyLogic = createProxyLogic(resultSet);
+
+        when(resultSet.next()).thenReturn(true);
+
+        when(resultSet.getObject(1)).thenReturn(5);
+
+        assertThat(invokeNext(resultSetProxyLogic)).isTrue();
+
+        invokeBeforeFirst(resultSetProxyLogic);
+        invokeNext(resultSetProxyLogic);
+
+        long result = invokeGetLong(resultSetProxyLogic, 1);
+
+        assertThat(result).isEqualTo(5L);
     }
 
 }


### PR DESCRIPTION
Suppose we have a number stored as a Postgres `INT`. RepeatableReadResultSetProxyLogic may cache this as an Integer (because Postgres JDBC driver returns an Integer in response to `ResultSet.getObject`). The next time a consumer asks this number as a `long` via `ResultSet.getLong`, a cast from int to long is triggered and fails.

Postgres JDBC ResultSet is perfectly able to return the number into compatible types. Therefore RepeatableReadResultSetProxyLogic should also be able to do that when retrieve results from its cache.