### PR TITLE
Add CachedRowSetImpl JDBC4.1 support with Spring-jdbc

### DIFF
--- a/src/main/java/net/ttddyy/dsproxy/proxy/SpringSqlRowSetProxyLogic.java
+++ b/src/main/java/net/ttddyy/dsproxy/proxy/SpringSqlRowSetProxyLogic.java
@@ -1,0 +1,151 @@
+package net.ttddyy.dsproxy.proxy;
+
+import net.ttddyy.dsproxy.ConnectionInfo;
+import net.ttddyy.dsproxy.listener.MethodExecutionListenerUtils;
+import org.springframework.jdbc.support.rowset.ResultSetWrappingSqlRowSet;
+
+import java.lang.reflect.Method;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+
+/**
+ * Delegate method calls to the {@link ResultSetWrappingSqlRowSet}.
+ * <br/>
+ * Provides support for JDBC 4.1 methods:
+ * <ul>
+ *     <li>{@link com.sun.rowset.CachedRowSetImpl#getObject(int, Class)}</li>
+ *     <li>{@link com.sun.rowset.CachedRowSetImpl#getObject(String, Class)}</li>
+ * </ul>
+ *
+ * @author a-simeshin
+ * @since 1.10
+ */
+@SuppressWarnings("Convert2Lambda")
+public class SpringSqlRowSetProxyLogic implements ResultSetProxyLogic {
+
+    private final ResultSet originalRowSet;
+    private final ResultSetWrappingSqlRowSet springRowSet;
+    private final ConnectionInfo connectionInfo;
+    private final ProxyConfig proxyConfig;
+
+    protected boolean supportIsClosedMethod = true;
+    protected boolean isClosed;
+
+    public SpringSqlRowSetProxyLogic(ResultSet originalRowSet,
+                                     ResultSetWrappingSqlRowSet springRowSet,
+                                     ConnectionInfo connectionInfo,
+                                     ProxyConfig proxyConfig) {
+        this.originalRowSet = originalRowSet;
+        this.springRowSet = springRowSet;
+        this.connectionInfo = connectionInfo;
+        this.proxyConfig = proxyConfig;
+    }
+
+    /**
+     * Invokes a method on the SqlRowSet proxy while listening to method execution through a callback.
+     *
+     * @param method The method being called on the SqlRowSet proxy.
+     * @param args The arguments passed to the method.
+     * @return The result of the method call.
+     * @throws Throwable If any error or exception occurs during the method execution.
+     */
+    @Override
+    public Object invoke(Method method, Object[] args) throws Throwable {
+        return MethodExecutionListenerUtils.invoke(new MethodExecutionListenerUtils.MethodExecutionCallback() {
+            @Override
+            public Object execute(Object proxyTarget, Method method, Object[] args) throws Throwable {
+                return performQueryExecutionListener(method, args);
+            }
+        }, this.proxyConfig, this.springRowSet, this.connectionInfo, method, args);
+    }
+
+    /**
+     * Performs query execution listener for a method call on the SqlRowSet proxy.
+     *
+     * @param method The method being called on the SqlRowSet proxy.
+     * @param args The arguments passed to the method.
+     * @return The result of the method call.
+     * @throws Throwable If any error or exception occurs during the method execution.
+     */
+    private Object performQueryExecutionListener(Method method, Object[] args) throws Throwable {
+        //TODO using switch - need JDK COMPATIBLE
+        final String methodName = method.getName();
+
+        if ("toString".equals(methodName)) {
+            return this.originalRowSet.getClass().getSimpleName() + " [" + this.originalRowSet + "]";
+        }
+        if ("hashCode".equals(methodName)) {
+            return this.originalRowSet.hashCode();
+        }
+        if ("equals".equals(methodName)) {
+            return this.originalRowSet.equals(args[0]);
+        }
+        if ("close".equals(methodName)) {
+            // 🤯🤯🤯
+            this.isClosed = true;
+            return null;
+        }
+        if (this.supportIsClosedMethod && "isClosed".equals(methodName)) {
+            return this.isClosed;
+        }
+        if ("getTarget".equals(methodName)) {
+            return this.originalRowSet;
+        }
+        if ("getMetaData".equals(methodName)) {
+            return this.originalRowSet.getMetaData();
+        }
+
+        try {
+            final Method newMethod = convertResultSetMethodToSpringSqlRowSetMethod(method);
+            return MethodUtils.proceedExecution(newMethod, this.springRowSet, args);
+        } catch (Throwable throwable) {
+            if (throwable instanceof SQLException) {
+                throw throwable;
+            }
+            final String reason = String.format("SqlRowSet threw exception: %s", throwable);
+            throw new SQLException(reason, throwable);
+        }
+    }
+
+    /**
+     * Converts a method from the original ResultSet-based interface to the corresponding method
+     * in the Spring SqlRowSet interface, using reflection.
+     *
+     * @param originalMethod The method to be converted from the ResultSet-based interface.
+     * @return The corresponding method from the Spring SqlRowSet interface, if found.
+     * @throws IllegalStateException If the corresponding method cannot be found in the Spring SqlRowSet interface.
+     */
+    private Method convertResultSetMethodToSpringSqlRowSetMethod(final Method originalMethod) {
+        final String originalMethodName = originalMethod.getName();
+        final Class<?>[] originalMethodParameterTypes = originalMethod.getParameterTypes();
+        final Method[] methods = this.springRowSet.getClass().getMethods();
+
+        for (Method method : methods) {
+            if (method.getName().equals(originalMethodName)) {
+                final Class<?>[] methodParameterTypes = method.getParameterTypes();
+                if (methodParameterTypes.length == originalMethodParameterTypes.length) {
+                    boolean match = true;
+                    for (int i = 0; i < originalMethodParameterTypes.length; i++) {
+                        if (!methodParameterTypes[i].isAssignableFrom(originalMethodParameterTypes[i])) {
+                            match = false;
+                            break;
+                        }
+                    }
+                    if (match) {
+                        return method;
+                    }
+                }
+            }
+        }
+
+        throw new IllegalStateException(
+                "Cannot find proxy method "
+                        + originalMethodName
+                        + " and types "
+                        + Arrays.toString(originalMethodParameterTypes)
+                        + " for class: "
+                        + springRowSet.getClass().getName());
+    }
+
+}

--- a/src/main/java/net/ttddyy/dsproxy/proxy/SpringSqlRowSetProxyLogicFactory.java
+++ b/src/main/java/net/ttddyy/dsproxy/proxy/SpringSqlRowSetProxyLogicFactory.java
@@ -1,0 +1,51 @@
+package net.ttddyy.dsproxy.proxy;
+
+import net.ttddyy.dsproxy.ConnectionInfo;
+import net.ttddyy.dsproxy.DataSourceProxyException;
+import org.springframework.jdbc.support.rowset.ResultSetWrappingSqlRowSet;
+
+import javax.sql.rowset.CachedRowSet;
+import javax.sql.rowset.RowSetFactory;
+import javax.sql.rowset.RowSetProvider;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Factory to create {@link SimpleResultSetProxyLogic}.
+ *
+ * @author a-simeshin
+ * @since 1.10
+ */
+public class SpringSqlRowSetProxyLogicFactory implements ResultSetProxyLogicFactory {
+
+    @Override
+    public ResultSetProxyLogic create(ResultSet resultSet, ConnectionInfo connectionInfo, ProxyConfig proxyConfig) {
+        final ResultSetWrappingSqlRowSet cachedRowSet = getCachedRowSet(resultSet);
+        return new SpringSqlRowSetProxyLogic(resultSet, cachedRowSet, connectionInfo, proxyConfig);
+    }
+
+    /**
+     * Retrieves a cached row set from the given ResultSet. If the ResultSet contains no columns,
+     * a ResultSetWrappingSqlRowSet is created directly from the ResultSet. Otherwise, a CachedRowSet
+     * is created using RowSetProvider and populated with the data from the ResultSet, and then wrapped
+     * in a ResultSetWrappingSqlRowSet.
+     *
+     * @param resultSet The ResultSet from which to create the cached row set.
+     * @return The cached row set as a ResultSetWrappingSqlRowSet.
+     * @throws DataSourceProxyException If an error occurs while creating the CachedRowSet.
+     */
+    protected ResultSetWrappingSqlRowSet getCachedRowSet(ResultSet resultSet) {
+        try {
+            if (resultSet.getMetaData().getColumnCount() == 0) {
+                return new ResultSetWrappingSqlRowSet(resultSet);
+            }
+            final RowSetFactory rowSetFactory = RowSetProvider.newFactory();
+            final CachedRowSet cachedRowSet = rowSetFactory.createCachedRowSet();
+            cachedRowSet.populate(resultSet);
+            return new ResultSetWrappingSqlRowSet(cachedRowSet);
+        } catch (SQLException e) {
+            throw new DataSourceProxyException("Failed to create ResultSetWrappingSqlRowSet", e);
+        }
+    }
+
+}

--- a/src/main/java/net/ttddyy/dsproxy/proxy/SpringSqlRowSetProxyLogicFactory.java
+++ b/src/main/java/net/ttddyy/dsproxy/proxy/SpringSqlRowSetProxyLogicFactory.java
@@ -11,7 +11,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 /**
- * Factory to create {@link SimpleResultSetProxyLogic}.
+ * Factory to create {@link SpringSqlRowSetProxyLogic}.
  *
  * @author a-simeshin
  * @since 1.10

--- a/src/test/java/net/ttddyy/dsproxy/proxy/SpringRowSetProxyLogicTest.java
+++ b/src/test/java/net/ttddyy/dsproxy/proxy/SpringRowSetProxyLogicTest.java
@@ -1,0 +1,344 @@
+package net.ttddyy.dsproxy.proxy;
+
+import net.ttddyy.dsproxy.ConnectionInfo;
+import net.ttddyy.dsproxy.TestUtils;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.sql.DataSource;
+import java.lang.reflect.Method;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class SpringRowSetProxyLogicTest {
+
+    private static final String COLUMN_1_LABEL = "id";
+    private static final String COLUMN_2_LABEL = "name";
+    private static final Integer COLUMN_1_ROW_1_VALUE = 1;
+    private static final String COLUMN_2_ROW_1_VALUE = "foo";
+    private static final Integer COLUMN_1_ROW_2_VALUE = 2;
+    private static final String COLUMN_2_ROW_2_VALUE = "bar";
+
+    private DataSource jdbcDataSource;
+
+    @Before
+    public void setUp() throws Exception {
+        this.jdbcDataSource = TestUtils.getDataSourceWithData();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        TestUtils.shutdown(this.jdbcDataSource);
+    }
+
+    @Test
+    public void unsupportedMethodsThrowUnsupportedOperationException() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        final SpringSqlRowSetProxyLogic resultSetProxyLogic = createProxyLogic(resultSet);
+
+        final Method getCursorName = ResultSet.class.getMethod("getCursorName");
+
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() throws Throwable {
+                resultSetProxyLogic.invoke(getCursorName, null);
+            }
+        }).isInstanceOf(SQLException.class);
+    }
+
+    @Test
+    public void getTargetReturnsTheResultSetFromTheTarget() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        SpringSqlRowSetProxyLogic resultSetProxyLogic = createProxyLogic(resultSet);
+
+        Method getTarget = ProxyJdbcObject.class.getMethod("getTarget");
+
+        Object result = resultSetProxyLogic.invoke(getTarget, null);
+
+        assertThat(result).isSameAs(resultSet);
+    }
+
+    @Test
+    public void getResultSetMetaDataReturnsTheResultSetMetaDataFromTheTarget() throws Throwable {
+        ResultSet originalResultSet = exampleResultSet();
+        ResultSetMetaData originalMetaData = originalResultSet.getMetaData();
+        SpringSqlRowSetProxyLogic resultSetProxyLogic = createProxyLogic(originalResultSet);
+
+        Method getMetaData = ResultSet.class.getMethod("getMetaData");
+        Object result = resultSetProxyLogic.invoke(getMetaData, null);
+
+        assertThat(result).isInstanceOf(ResultSetMetaData.class);
+        ResultSetMetaData metaData = (ResultSetMetaData) result;
+        assertThat(metaData.getColumnCount()).isEqualTo(originalMetaData.getColumnCount());
+    }
+
+    @Test
+    public void closeCallsCloseOnTheTarget() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        SpringSqlRowSetProxyLogic resultSetProxyLogic = createProxyLogic(resultSet);
+
+        invokeClose(resultSetProxyLogic);
+    }
+
+    @Test
+    public void getColumnOnResultSetThatHasBeenConsumedTwiceThrowsException() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        final SpringSqlRowSetProxyLogic resultSetProxyLogic = createProxyLogic(resultSet);
+
+        consumeResultSetAndCallBeforeFirst(resultSetProxyLogic);
+        consumeResultSet(resultSetProxyLogic);
+
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() throws Throwable {
+                SpringRowSetProxyLogicTest.this.invokeGetString(resultSetProxyLogic, 1);
+            }
+        }).isInstanceOf(SQLException.class);
+    }
+
+    @Test
+    public void getColumnOnClosedResultSetThatHasBeenConsumedOnceThrowsException() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        final SpringSqlRowSetProxyLogic resultSetProxyLogic = createProxyLogic(resultSet);
+
+        consumeResultSetAndCallBeforeFirst(resultSetProxyLogic);
+        invokeClose(resultSetProxyLogic);
+
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() throws Throwable {
+                SpringRowSetProxyLogicTest.this.invokeGetString(resultSetProxyLogic, 1);
+            }
+        }).isInstanceOf(SQLException.class);
+    }
+
+    @Test
+    public void nextOnUnconsumedResultSetThatHasMoreResultsDelegatesToTheTarget() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        SpringSqlRowSetProxyLogic resultSetProxyLogic = createProxyLogic(resultSet);
+
+        boolean result = invokeNext(resultSetProxyLogic);
+
+        assertThat(result).isEqualTo(true);
+    }
+
+    @Test
+    public void nextOnUnconsumedResultThatHasNoMoreResultsSetDelegatesToTheTarget() throws Throwable {
+        Connection connection = this.jdbcDataSource.getConnection();
+        Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery("select * from emp where id = 1000");
+
+        SpringSqlRowSetProxyLogic resultSetProxyLogic = createProxyLogic(resultSet);
+
+        boolean result = invokeNext(resultSetProxyLogic);
+
+        assertThat(result).isEqualTo(false);
+    }
+
+    @Test
+    public void getColumnByIndexOnUnconsumedResultSetThatHasMoreResultsDelegatesToTheTarget() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        SpringSqlRowSetProxyLogic resultSetProxyLogic = createProxyLogic(resultSet);
+        invokeNext(resultSetProxyLogic);
+
+        Integer result = invokeGetInt(resultSetProxyLogic, 1);
+
+        assertThat(result).isEqualTo(COLUMN_1_ROW_1_VALUE);
+    }
+
+    @Test
+    public void getColumnByLabelOnUnconsumedResultSetThatHasMoreResultsDelegatesToTheTarget() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        SpringSqlRowSetProxyLogic resultSetProxyLogic = createProxyLogic(resultSet);
+        invokeNext(resultSetProxyLogic);
+
+        Integer result = invokeGetInt(resultSetProxyLogic, COLUMN_1_LABEL);
+
+        assertThat(result).isEqualTo(COLUMN_1_ROW_1_VALUE);
+    }
+
+    @Test
+    public void getColumnByIndexOnConsumedResultSetBeforeCallingNextThrowsSQLException() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        final SpringSqlRowSetProxyLogic resultSetProxyLogic = createProxyLogic(resultSet);
+
+        consumeResultSetAndCallBeforeFirst(resultSetProxyLogic);
+
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() throws Throwable {
+                SpringRowSetProxyLogicTest.this.invokeGetString(resultSetProxyLogic, 1);
+            }
+        }).isInstanceOf(SQLException.class);
+    }
+
+    @Test
+    public void getColumnByIndexOnConsumedResultSetThatHasMoreResultsReturnsTheResultThatTheTargetDidTheFirstTime() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        SpringSqlRowSetProxyLogic resultSetProxyLogic = createProxyLogic(resultSet);
+
+        consumeResultSetAndCallBeforeFirst(resultSetProxyLogic);
+        invokeNext(resultSetProxyLogic);
+
+        Integer result = invokeGetInt(resultSetProxyLogic, 1);
+
+        assertThat(result).isEqualTo(COLUMN_1_ROW_1_VALUE);
+    }
+
+    @Test
+    public void getColumnByNotExplicitelyConsumedIndexOnConsumedResultSetThatHasMoreResultsReturnsTheResultThatTheTargetDidTheFirstTime() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        SpringSqlRowSetProxyLogic resultSetProxyLogic = createProxyLogic(resultSet);
+
+        assertThat(invokeNext(resultSetProxyLogic)).isTrue();
+
+        invokeBeforeFirst(resultSetProxyLogic);
+        invokeNext(resultSetProxyLogic);
+
+        Integer result = invokeGetInt(resultSetProxyLogic, 1);
+
+        assertThat(result).isEqualTo(COLUMN_1_ROW_1_VALUE);
+    }
+
+    @Test
+    public void getColumnByLabelOnConsumedResultSetThatHasMoreResultsReturnsTheResultThatTheTargetDidTheFirstTime() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        SpringSqlRowSetProxyLogic resultSetProxyLogic = createProxyLogic(resultSet);
+
+        consumeResultSetAndCallBeforeFirst(resultSetProxyLogic);
+        invokeNext(resultSetProxyLogic);
+
+        Integer result = invokeGetInt(resultSetProxyLogic, COLUMN_1_LABEL);
+
+        assertThat(result).isEqualTo(COLUMN_1_ROW_1_VALUE);
+    }
+
+    @Test
+    public void getColumnByLabelOnConsumedResultSetWithUnknownLabelThrowsIllegalArgumentException() throws Throwable {
+        ResultSet resultSet = exampleResultSet();
+        final SpringSqlRowSetProxyLogic resultSetProxyLogic = createProxyLogic(resultSet);
+
+        consumeResultSetAndCallBeforeFirst(resultSetProxyLogic);
+        invokeNext(resultSetProxyLogic);
+
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() throws Throwable {
+                invokeGetString(resultSetProxyLogic, "bad");
+            }
+        }).isInstanceOf(SQLException.class);
+    }
+
+    private SpringSqlRowSetProxyLogic createProxyLogic(ResultSet resultSet) {
+        SpringSqlRowSetProxyLogicFactory factory = new SpringSqlRowSetProxyLogicFactory();
+        return (SpringSqlRowSetProxyLogic) factory.create(resultSet, new ConnectionInfo(), ProxyConfig.Builder.create().build());
+    }
+
+    private void consumeResultSetAndCallBeforeFirst(SpringSqlRowSetProxyLogic resultSetProxyLogic) throws Throwable {
+        consumeResultSet(resultSetProxyLogic);
+        invokeBeforeFirst(resultSetProxyLogic);
+    }
+
+    private void consumeResultSet(SpringSqlRowSetProxyLogic resultSetProxyLogic) throws Throwable {
+        assertThat(invokeNext(resultSetProxyLogic)).isTrue();
+        assertThat(invokeGetInt(resultSetProxyLogic, COLUMN_1_LABEL)).isEqualTo(COLUMN_1_ROW_1_VALUE);
+        assertThat(invokeGetString(resultSetProxyLogic, 2)).isEqualTo(COLUMN_2_ROW_1_VALUE);
+
+        assertThat(invokeNext(resultSetProxyLogic)).isTrue();
+        assertThat(invokeGetInt(resultSetProxyLogic, 1)).isEqualTo(COLUMN_1_ROW_2_VALUE);
+        assertThat(invokeGetString(resultSetProxyLogic, COLUMN_2_LABEL)).isEqualTo(COLUMN_2_ROW_2_VALUE);
+
+        assertThat(invokeNext(resultSetProxyLogic)).isFalse();
+    }
+
+    private void invokeClose(SpringSqlRowSetProxyLogic resultSetProxyLogic) throws Throwable {
+        Method next = ResultSet.class.getMethod("close");
+        resultSetProxyLogic.invoke(next, null);
+    }
+
+    private void invokeBeforeFirst(SpringSqlRowSetProxyLogic resultSetProxyLogic) throws Throwable {
+        Method beforeFirst = ResultSet.class.getMethod("beforeFirst");
+        resultSetProxyLogic.invoke(beforeFirst, null);
+    }
+
+    private boolean invokeNext(SpringSqlRowSetProxyLogic resultSetProxyLogic) throws Throwable {
+        Method next = ResultSet.class.getMethod("next");
+        return (Boolean) resultSetProxyLogic.invoke(next, null);
+    }
+
+    private String invokeGetString(SpringSqlRowSetProxyLogic resultSetProxyLogic, int columnIndex) throws Throwable {
+        Method getString = ResultSet.class.getMethod("getString", int.class);
+        return (String) resultSetProxyLogic.invoke(getString, new Object[]{columnIndex});
+    }
+
+    private int invokeGetInt(SpringSqlRowSetProxyLogic resultSetProxyLogic, int columnIndex) throws Throwable {
+        Method getInt = ResultSet.class.getMethod("getInt", int.class);
+        return (Integer) resultSetProxyLogic.invoke(getInt, new Object[]{columnIndex});
+    }
+
+    private String invokeGetString(SpringSqlRowSetProxyLogic resultSetProxyLogic, String columnLabel) throws Throwable {
+        Method getString = ResultSet.class.getMethod("getString", String.class);
+        return (String) resultSetProxyLogic.invoke(getString, new Object[]{columnLabel});
+    }
+
+    private int invokeGetInt(SpringSqlRowSetProxyLogic resultSetProxyLogic, String columnLabel) throws Throwable {
+        Method getInt = ResultSet.class.getMethod("getInt", String.class);
+        return (Integer) resultSetProxyLogic.invoke(getInt, new Object[]{columnLabel});
+    }
+
+    private ResultSet exampleResultSet() throws SQLException {
+        Connection connection = this.jdbcDataSource.getConnection();
+        Statement statement = connection.createStatement();
+        return statement.executeQuery("select * from emp");
+    }
+
+
+    @Test
+    public void testToString() throws Throwable {
+
+        ResultSet rs = exampleResultSet();
+        SpringSqlRowSetProxyLogic logic = createProxyLogic(rs);
+
+        Method method = Object.class.getMethod("toString");
+        Object result = logic.invoke(method, null);
+
+        assertThat(result).isInstanceOf(String.class)
+                .asString().contains(rs.getClass().getSimpleName()).contains("[").contains("]");
+    }
+
+    @Test
+    public void testHashCode() throws Throwable {
+        ResultSet rs = exampleResultSet();
+        SpringSqlRowSetProxyLogic logic = createProxyLogic(rs);
+
+        Method method = Object.class.getMethod("hashCode");
+        Object result = logic.invoke(method, null);
+
+        assertThat(result).isInstanceOf(Integer.class).isEqualTo(rs.hashCode());
+    }
+
+    @Test
+    public void testEquals() throws Throwable {
+        ResultSet rs = exampleResultSet();
+        SpringSqlRowSetProxyLogic logic = createProxyLogic(rs);
+
+        Method method = Object.class.getMethod("equals", Object.class);
+
+        // equals(null)
+        Object result = logic.invoke(method, new Object[]{null});
+        assertThat(result).isEqualTo(false);
+
+        // equals(true)
+        result = logic.invoke(method, new Object[]{rs});
+        assertThat(result).isEqualTo(true);
+    }
+
+}


### PR DESCRIPTION
Hi there!

I`d like to add support for JDBC 4.1 operations with caching ResultSet.

Unfortunately the current implementation of `CachedRowSetResultSetProxyLogic` uses `com.sun.rowset.CachedRowSetImpl` by default, which in turn does not support JDBC 4.1 operations (looked at OpenJDK11,17):
```java
    public <T> T getObject(int var1, Class<T> var2) throws SQLException {
        throw new SQLFeatureNotSupportedException("Not supported yet.");
    }

    public <T> T getObject(String var1, Class<T> var2) throws SQLException {
        throw new SQLFeatureNotSupportedException("Not supported yet.");
    }
```

I can't even find a JEP for revising this class to update and implement these methods, or any good oportunties to work with, however I was able to find a wrapper above the `com.sun.rowset.CachedRowSetImpl` in `Spring-jdbc` - [ResultSetWrappingSqlRowSet](https://github.com/spring-projects/spring-framework/blob/4786e2bf53a3f882c10e25d7ff79a18ff47b5e51/spring-jdbc/src/main/java/org/springframework/jdbc/support/rowset/ResultSetWrappingSqlRowSet.java#L431) 
In addition to the missing methods, there is already a proxy for all the methods that are important for obtaining data.

Here another small problem appears, I didn’t figure out how to change the current logic of `CachedRowSetResultSetProxyLogic`, since work is being done there with `ResultSet` by which we usually understand `CachedRowSetImpl`, but `ResultSetWrappingSqlRowSet` does not implement the `ResultSet` interface - instead, there is [SqlRowSet](https://github.com/spring-projects/spring-framework/blob/main/spring-jdbc/src/main/java/org/springframework/jdbc/support/rowset/SqlRowSet.java#L51) in the `Spring-jdbc`. 

So I make one more variant of `ResultSetProxyLogic` without touching `CachedRowSetResultSetProxyLogic` in order to avoid problems with backward compatibility and the need to depend on `Spring-jdbc`.

I would be happy to discuss how It can be made easier 😭